### PR TITLE
Handle a null properly in SelectedItem set

### DIFF
--- a/src/SadConsole.Shared/Controls/ListBox.cs
+++ b/src/SadConsole.Shared/Controls/ListBox.cs
@@ -139,24 +139,34 @@ namespace SadConsole.Controls
             }
         }
 
-        public object SelectedItem
-        {
-            get => selectedItem;
-            set
-            {
-                var index = Items.IndexOf(value);
+	    public object SelectedItem
+	    {
+		    get => selectedItem;
+		    set
+		    {
+			    if (value == null)
+			    {
+				    selectedIndex = -1;
+				    selectedItem = null;
+				    IsDirty = true;
+				    OnSelectedItemChanged();
+			    }
+			    else
+			    {
+				    var index = Items.IndexOf(value);
 
-                if (index == -1)
-                    throw new ArgumentOutOfRangeException("Item does not exist in collection.");
+				    if (index == -1)
+					    throw new ArgumentOutOfRangeException("Item does not exist in collection.");
 
-                selectedIndex = index;
-                selectedItem = Items[index];
-                IsDirty = true;
-                OnSelectedItemChanged();
-            }
-        }
+				    selectedIndex = index;
+				    selectedItem = Items[index];
+				    IsDirty = true;
+				    OnSelectedItemChanged();
+			    }
+		    }
+	    }
 
-        public Point ScrollBarOffset
+		public Point ScrollBarOffset
         {
             get => scrollBarOffset;
             set { scrollBarOffset = value; SetupSlider();  }


### PR DESCRIPTION
Okay - I think I did the pull request properly.  Let me know if not.  Anyway, it's a simple fix - the old SelectedItem set routine in ListBox tried to find the value in the list box which, of course, wouldn't work if you were trying to turn off the selection by setting it to null.  This explicitly happens in the code if you delete the currently selected object which is how I saw it.  So I just check for null there and do the right thing - else, I run the old code intact.