### PR TITLE
double and int parse methods are now called with an Invariant culture

### DIFF
--- a/src/SadConsole.Shared/StringParser/ParseCommandBlink.cs
+++ b/src/SadConsole.Shared/StringParser/ParseCommandBlink.cs
@@ -1,6 +1,7 @@
 ﻿using SadConsole.Surfaces;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 
 namespace SadConsole.StringParser
@@ -19,10 +20,10 @@ namespace SadConsole.StringParser
             string[] parametersArray = parameters.Split(':');
 
             if (parametersArray.Length == 2)
-                Speed = double.Parse(parametersArray[1]);
+                Speed = double.Parse(parametersArray[1], CultureInfo.InvariantCulture);
 
             if (parametersArray.Length >= 1 && parametersArray[0] != "")
-                Counter = int.Parse(parametersArray[0]);
+                Counter = int.Parse(parametersArray[0], CultureInfo.InvariantCulture);
             else
                 Counter = -1;
 

--- a/src/SadConsole.Shared/StringParser/ParseCommandGlyph.cs
+++ b/src/SadConsole.Shared/StringParser/ParseCommandGlyph.cs
@@ -2,6 +2,7 @@
 using SadConsole.Surfaces;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 
 namespace SadConsole.StringParser
@@ -28,10 +29,10 @@ namespace SadConsole.StringParser
                 if (parts[0] == "*")
                     Counter = -1;
                 else
-                    Counter = int.Parse(parts[0]);
+                    Counter = int.Parse(parts[0], CultureInfo.InvariantCulture);
 
-                RandomGlyphMin = int.Parse(parts[1]);
-                RandomGlyphMax = int.Parse(parts[2]);
+                RandomGlyphMin = int.Parse(parts[1], CultureInfo.InvariantCulture);
+                RandomGlyphMax = int.Parse(parts[2], CultureInfo.InvariantCulture);
             }
             // Count and glyph type provided
             else if (parts.Length == 2)
@@ -39,14 +40,14 @@ namespace SadConsole.StringParser
                 if (parts[1] == "*")
                     Counter = -1;
                 else
-                    Counter = int.Parse(parts[1]);
+                    Counter = int.Parse(parts[1], CultureInfo.InvariantCulture);
 
-                Glyph = (char)int.Parse(parts[0]);
+                Glyph = (char)int.Parse(parts[0], CultureInfo.InvariantCulture);
             }
             else
             {
                 Counter = 1;
-                Glyph = (char)int.Parse(parts[0]);
+                Glyph = (char)int.Parse(parts[0], CultureInfo.InvariantCulture);
             }
 
 

--- a/src/SadConsole.Shared/StringParser/ParseCommandGradient.cs
+++ b/src/SadConsole.Shared/StringParser/ParseCommandGradient.cs
@@ -2,6 +2,7 @@
 using SadConsole.Surfaces;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 
 namespace SadConsole.StringParser
@@ -25,7 +26,7 @@ namespace SadConsole.StringParser
             if (parametersArray.Length > 3)
             {
                 CommandType = parametersArray[0] == "b" ? CommandTypes.Background : CommandTypes.Foreground;
-                Counter = Length = int.Parse(parametersArray[parametersArray.Length - 1]);
+                Counter = Length = int.Parse(parametersArray[parametersArray.Length - 1], CultureInfo.InvariantCulture);
 
                 bool keep;
                 bool useDefault;

--- a/src/SadConsole.Shared/StringParser/ParseCommandMirror.cs
+++ b/src/SadConsole.Shared/StringParser/ParseCommandMirror.cs
@@ -2,6 +2,7 @@
 
 using SadConsole.Surfaces;
 using System;
+using System.Globalization;
 
 namespace SadConsole.StringParser
 {
@@ -21,7 +22,7 @@ namespace SadConsole.StringParser
             string[] paramArray = parameters.Split(':');
 
             if (paramArray.Length == 2)
-                Counter = int.Parse(paramArray[1]);
+                Counter = int.Parse(paramArray[1], CultureInfo.InvariantCulture);
             else
                 Counter = -1;
 

--- a/src/SadConsole.Shared/StringParser/ParseCommandRecolor.cs
+++ b/src/SadConsole.Shared/StringParser/ParseCommandRecolor.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
 using SadConsole.Surfaces;
 using System;
+using System.Globalization;
 
 namespace SadConsole.StringParser
 {
@@ -29,7 +30,7 @@ namespace SadConsole.StringParser
             string[] parametersArray = parameters.Split(':');
 
             if (parametersArray.Length == 3)
-                Counter = int.Parse(parametersArray[2]);
+                Counter = int.Parse(parametersArray[2], CultureInfo.InvariantCulture);
             else
                 Counter = -1;
 

--- a/src/SadConsole.Shared/StringParser/ParseCommandUndo.cs
+++ b/src/SadConsole.Shared/StringParser/ParseCommandUndo.cs
@@ -1,6 +1,7 @@
 ﻿using SadConsole.Surfaces;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 
 namespace SadConsole.StringParser
@@ -48,7 +49,7 @@ namespace SadConsole.StringParser
             }
 
             if (parts.Length >= 1 && parts[0] != "")
-                times = int.Parse(parts[0]);
+                times = int.Parse(parts[0], CultureInfo.InvariantCulture);
 
 
             for (int i = 0; i < times; i++)


### PR DESCRIPTION
To avoid issues on machine with different culture settings, it is a good practice to specify an invariant culture for parsing methods.