### PR TITLE
Changed occurrences of "Done" to "IsFinished" to match variable name

### DIFF
--- a/src/SadConsole.Shared/Instructions/InstructionBase.cs
+++ b/src/SadConsole.Shared/Instructions/InstructionBase.cs
@@ -87,9 +87,9 @@
 
             OnExecutionRepeating();
         }
-        
+
         /// <summary>
-        /// Executes the instruction. This base class method should be called from derived classes. If the Done property is set to true, will try to repeat if needed and will raise all appropriate events.
+        /// Executes the instruction. This base class method should be called from derived classes. If the IsFinished property is set to true, will try to repeat if needed and will raise all appropriate events.
         /// </summary>
         public virtual void Run()
         {

--- a/src/SadConsole.Shared/Instructions/InstructionSet.cs
+++ b/src/SadConsole.Shared/Instructions/InstructionSet.cs
@@ -40,7 +40,7 @@
         }
 
         /// <summary>
-        /// Runs the instruction set. Once all instructions are Done, this set will set the <see cref="Done"/> property will be set to true.
+        /// Runs the instruction set. Once all instructions are done, this set will set the <see cref="IsFinished"/> property will be set to true.
         /// </summary>
         public override void Run()
         {


### PR DESCRIPTION
Caught a couple mentions of the term "Done" instead of IsFinished, which the property is now called.