### PR TITLE
Demo refactor

### DIFF
--- a/src/DemoProject/SharedCode/CustomConsoles/ScrollableConsole.cs
+++ b/src/DemoProject/SharedCode/CustomConsoles/ScrollableConsole.cs
@@ -75,7 +75,7 @@ namespace StarterProject.CustomConsoles
 
             //If cursor position exceeds our displayable content viewport, 
             //move the ScrollOffset automatically to display new content.
-            if (TimesShiftedUp != 0 | Cursor.Position.Y == ViewPort.Height + ScrollOffset)
+            if (TimesShiftedUp != 0 | Cursor.Position.Y >= ViewPort.Height + ScrollOffset)
             {
                 //Scollbar has to be enabled to read previous content.
                 _scrollBar.IsEnabled = true;

--- a/src/DemoProject/SharedCode/CustomConsoles/ScrollableConsole.cs
+++ b/src/DemoProject/SharedCode/CustomConsoles/ScrollableConsole.cs
@@ -1,90 +1,92 @@
-﻿using Microsoft.Xna.Framework;
-
-using System;
-using System.Collections.Generic;
-using System.Text;
-using SadConsole.Input;
+﻿using System;
+using Microsoft.Xna.Framework;
 using SadConsole;
-using Console = SadConsole.Console;
+using SadConsole.Controls;
+using SadConsole.Input;
 
 namespace StarterProject.CustomConsoles
 {
-    class ScrollableConsole : ScrollingConsole
+    public class ScrollableConsole : ScrollingConsole
     {
-        SadConsole.ControlsConsole controlsContainer;
-        SadConsole.Controls.ScrollBar scrollBar;
+        private readonly ControlsConsole _controlsContainer;
+        private readonly ScrollBar _scrollBar;
 
-        int scrollingCounter;
+        ///<summary>Scroll bar position.</summary>
+        public int ScrollOffset { get; private set; } = 0;
 
-        public ScrollableConsole(int width, int height, int bufferHeight) : base(width - 1, bufferHeight, Global.FontDefault, new Rectangle(0,0,width - 1,height))
+        public ScrollableConsole(int width, int height, int bufferHeight) :
+            base(
+                width: width - 1, 
+                height: bufferHeight, 
+                font: Global.FontDefault,
+                viewPort: new Rectangle(0, 0, width - 1, height))
         {
-            controlsContainer = new SadConsole.ControlsConsole(1, height);
+            _controlsContainer = new ControlsConsole(1, height);
 
             ViewPort = new Rectangle(0, 0, width, height);
 
-            scrollBar = new SadConsole.Controls.ScrollBar(Orientation.Vertical, height);
-            scrollBar.IsEnabled = false;
-            scrollBar.ValueChanged += ScrollBar_ValueChanged;
+            _scrollBar = new ScrollBar(Orientation.Vertical, height);
+            _scrollBar.IsEnabled = false;
+            _scrollBar.ValueChanged += ScrollBar_ValueChanged;
 
-            controlsContainer.Add(scrollBar);
-            controlsContainer.Position = new Point(Position.X + width - 1, Position.Y);
-            controlsContainer.IsVisible = true;
+            _controlsContainer.Add(_scrollBar);
+            _controlsContainer.Position = new Point(Position.X + width - 1, Position.Y);
+            _controlsContainer.IsVisible = true;
 
             Cursor.IsVisible = true;
             Cursor.Print("Just start typing!");
             IsVisible = false;
-
-            scrollingCounter = 0;
         }
 
         private void ScrollBar_ValueChanged(object sender, EventArgs e)
         {
-            // Do our scroll according to where the scroll bar value is
-            ViewPort = new Rectangle(0, scrollBar.Value, Width, ViewPort.Height);
+            //Display viewable content based on our scroll offset.
+            ViewPort = new Rectangle(0, _scrollBar.Value, Width, ViewPort.Height);
         }
 
         protected override void OnPositionChanged(Point oldLocation)
         {
-            // Keep the controls console (which is our scroll bar) in sync with where this console is.
-            controlsContainer.Position = new Point(Position.X + Width, Position.Y);
+            //Keep the controls console (which is our scroll bar) in sync with where this console is.
+            _controlsContainer.Position = new Point(Position.X + Width, Position.Y);
         }
 
         protected override void OnVisibleChanged()
         {
-            // Show and hide the scroll bar.
-            controlsContainer.IsVisible = this.IsVisible;
+            _controlsContainer.IsVisible = this.IsVisible;
         }
 
         public override void Draw(TimeSpan delta)
         {
             // Draw our console and then draw the scroll bar.
             base.Draw(delta);
-            controlsContainer.Draw(delta);
+            _controlsContainer.Draw(delta);
         }
 
         public override void Update(TimeSpan delta)
         {
             // Update our console and then update the scroll bar
             base.Update(delta);
-            controlsContainer.Update(delta);
+            _controlsContainer.Update(delta);
 
-            // If we detect that this console has shifted the data up for any reason (like the virtual cursor reached the
-            // bottom of the entire text surface, OR we reached the bottom of the render area, we need to adjust the 
-            // scroll bar and follow the cursor
-            if (TimesShiftedUp != 0 | Cursor.Position.Y == ViewPort.Height + scrollingCounter)
+            //If cursor position exceeds our displayable content viewport, 
+            //move the ScrollOffset automatically to display new content.
+            if (TimesShiftedUp != 0 | Cursor.Position.Y == ViewPort.Height + ScrollOffset)
             {
-                // Once the buffer has finally been filled enough to need scrolling, turn on the scroll bar
-                scrollBar.IsEnabled = true;
+                //Scollbar has to be enabled to read previous content.
+                _scrollBar.IsEnabled = true;
 
-                // Make sure we've never scrolled the entire size of the buffer
-                if (scrollingCounter < Height - ViewPort.Height)
-                    // Record how much we've scrolled to enable how far back the bar can see
-                    scrollingCounter += TimesShiftedUp != 0 ? TimesShiftedUp : 1;
+                //Cursor offset cannot exceed our viewable data end row.
+                //Think about it, we would reach infinity and empty space D:
+                if (ScrollOffset < Height - ViewPort.Height)
+                {
+                    //Automatically calculate our content viewport by scrolling the cursor
+                    //Based on how much content is inaccessible.
+                    ScrollOffset += TimesShiftedUp != 0 ? TimesShiftedUp : 1;
+                }
+                _scrollBar.Maximum = (Height + ScrollOffset) - Height;
 
-                scrollBar.Maximum = (Height + scrollingCounter) - Height;
-
-                // This will follow the cursor since we move the render area in the event.
-                scrollBar.Value = scrollingCounter;
+                //This will follow the cursor since we move the render area in the event.
+                _scrollBar.Value = ScrollOffset;
 
                 // Reset the shift amount.
                 TimesShiftedUp = 0;
@@ -93,17 +95,17 @@ namespace StarterProject.CustomConsoles
 
         public override bool ProcessMouse(MouseConsoleState state)
         {
-            // Create a new temp state based on the our "behind the scenes" console that holds the scroll bar
-            var stateForScroll = new MouseConsoleState(controlsContainer, state.Mouse);
+            //Create a state based on our container that has the scroll bar.
+            var stateForScroll = new MouseConsoleState(_controlsContainer, state.Mouse);
 
-            // Check if this state, based on the console holding the scroll bar
+            //Check if this state based on the console holding the scroll bar.
             if (stateForScroll.IsOnConsole)
             {
-                controlsContainer.ProcessMouse(stateForScroll);
+                _controlsContainer.ProcessMouse(stateForScroll);
                 return true;
             }
 
-            // if we're here, process the mouse like normal.
+            //If we're here, continue the mouse processing flow ordinarily.
             return base.ProcessMouse(state);
         }
     }

--- a/src/DemoProject/SharedCode/CustomConsoles/ScrollableConsole.cs
+++ b/src/DemoProject/SharedCode/CustomConsoles/ScrollableConsole.cs
@@ -14,6 +14,12 @@ namespace StarterProject.CustomConsoles
         ///<summary>Scroll bar position.</summary>
         public int ScrollOffset { get; private set; } = 0;
 
+        public bool ScrollbarIsVisible
+        {
+            get => _controlsContainer.IsVisible;
+            set => _controlsContainer.IsVisible = value;
+        }
+
         public ScrollableConsole(int width, int height, int bufferHeight) :
             base(
                 width: width - 1, 
@@ -35,7 +41,6 @@ namespace StarterProject.CustomConsoles
 
             Cursor.IsVisible = true;
             Cursor.Print("Just start typing!");
-            IsVisible = false;
         }
 
         private void ScrollBar_ValueChanged(object sender, EventArgs e)


### PR DESCRIPTION
Refactoring ScrollingConsole.

Fixed a bug where consoles, that inherited from `ScrollingConsole` would become stuck if the `Cursor.Position.Y` value changed more than 1 in a single update cycle: https://github.com/SadConsole/SadConsole/commit/fe63e775e411a6459884fdb658a62e464c7aa38c