### PR TITLE
Fixed font row calculation when padding is involved

### DIFF
--- a/src/SadConsole/FontMaster.cs
+++ b/src/SadConsole/FontMaster.cs
@@ -73,7 +73,7 @@ namespace SadConsole
         /// <summary>
         /// The total rows in the font.
         /// </summary>
-        public int Rows => Image.Height / (GlyphHeight + GlyphPadding);
+        public int Rows => Math.Ceiling(Image.Height / (GlyphHeight + GlyphPadding));
 
         /// <summary>
         /// The texture used by the font.

--- a/src/SadConsole/FontMaster.cs
+++ b/src/SadConsole/FontMaster.cs
@@ -73,7 +73,7 @@ namespace SadConsole
         /// <summary>
         /// The total rows in the font.
         /// </summary>
-        public int Rows => Math.Ceiling(Image.Height / (GlyphHeight + GlyphPadding));
+        public int Rows => (int)Math.Ceiling((double)Image.Height / (GlyphHeight + GlyphPadding));
 
         /// <summary>
         /// The texture used by the font.


### PR DESCRIPTION
The current row calculation is wrong when the font has padding.
My example:
Picture size: 543 pixel
Glyph size: 16 pixel
Padding: 1 pixel
Expected result: 32
Current calculation = 543 / (16 + 1) = 31.94 = 31 (rounded down due to indirect int cast)
New calculation = Math.Ceiling(543 / (16 + 1)) = Math.Ceiling(31.94) = 32